### PR TITLE
Fixes issue with relative /storage filepaths on some hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### v0.1.6
+– `Fixed` Fixes issue with relative /storage filepaths on some hosts
+
 #### v0.1.5
 - `Fixed` No-cache blocks now function correctly in loops
 

--- a/nocache/NoCachePlugin.php
+++ b/nocache/NoCachePlugin.php
@@ -22,7 +22,7 @@ class NoCachePlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '0.1.5';
+		return '0.1.6';
 	}
 
 	public function getCraftMinimumVersion()
@@ -92,7 +92,9 @@ class NoCachePlugin extends BasePlugin
 			// Watch for `nocache` blocks only if it's a site request
 			if(craft()->request->isSiteRequest())
 			{
-				// Capture the raw request output right before it's sent to the requester
+				// Capture the raw request output right before it's sent to the requester.
+				// Note: working directory may change during `register_shutdown_function`, so let's deal with that by caching our current working directory to a constant
+				define('NOCACHEPLUGIN_CWD', getcwd());
 				register_shutdown_function(function()
 				{
 					$output = ob_get_clean();
@@ -102,7 +104,10 @@ class NoCachePlugin extends BasePlugin
 					{
 						$id = $matches[1];
 						$type = $matches[2];
-
+						// Change working directory if need be
+						if (getcwd() !== NOCACHEPLUGIN_CWD) {
+							chdir(NOCACHEPLUGIN_CWD);
+						}
 						// Force-render the internals of the `nocache` tag and put it in place of the placeholder
 						return craft()->noCache->render($id, $type);
 

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,13 @@
 [
 	{
+		"version": "0.1.6",
+		"downloadUrl": "https://github.com/benjamminf/craft-nocache/archive/0.1.6.zip",
+		"date": "2016-10-07T20:00:00+10:00",
+		"notes": [
+			"[Fixed] Fixes issue with relative /storage filepaths on some hosts"
+		]
+	},
+	{
 		"version": "0.1.5",
 		"downloadUrl": "https://github.com/benjamminf/craft-nocache/archive/0.1.5.zip",
 		"date": "2016-07-11T19:57:00+10:00",


### PR DESCRIPTION
As noted in [the official PHP docs](http://php.net/manual/en/function.register-shutdown-function.php#59300), the `register_shutdown_function` method may change working directory on some hosts. This causes No-Cache to choke for setups using relative filepaths for the `/storage` directory (e.g. `"../storage"` for users who put the storage folder above the core folder).

This PR adds a simple fix for this issue, where No-Cache will cache the current (real!) working directory to a constant, before changing back to that directory inside the `register_shutdown_function` handler, if it needs to. Seems to work fine on my end.

Of course, another approach is to set `CRAFT_STORAGE_PATH` to an absolute path in the first place – e.g. using `realpath('../storage')`.
